### PR TITLE
fix: @dassie/lib-reactive import error

### DIFF
--- a/packages/lib-reactive-react/package.json
+++ b/packages/lib-reactive-react/package.json
@@ -30,6 +30,7 @@
   "author": "Stefan Thomas <justmoon@members.fsf.org>",
   "license": "Apache-2.0",
   "dependencies": {
+    "@dassie/lib-reactive": "workspace:^1.0.0",
     "@dassie/lib-type-utils": "workspace:^1.0.0"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -427,10 +427,12 @@ importers:
 
   packages/lib-reactive-react:
     specifiers:
+      '@dassie/lib-reactive': workspace:^1.0.0
       '@dassie/lib-type-utils': workspace:^1.0.0
       react: ^18.2.0
       type-fest: ^3.1.0
     dependencies:
+      '@dassie/lib-reactive': link:../lib-reactive
       '@dassie/lib-type-utils': link:../lib-type-utils
     devDependencies:
       react: 18.2.0


### PR DESCRIPTION
Fix the following errors that occur when executing the `pnpm start` command.

```
4:19:11 [vite] Internal server error: Failed to resolve import "@dassie/lib-reactive" from "packages/lib-reactive-react/src/index.ts". Does the file exist?
  Plugin: vite:import-analysis
  File: /Users/tequ/project/dassie/packages/lib-reactive-react/src/index.ts:10:54
  7  |    useSyncExternalStore
  8  |  } from "react";
  9  |  import { EffectContext, createReactor } from "@dassie/lib-reactive";
     |                                                ^
  10 |  const noop = () => {
  11 |  };
      at formatError (file:///Users/tequ/project/dassie/node_modules/.pnpm/vite@3.2.2/node_modules/vite/dist/node/chunks/dep-c842e491.js:41168:46)
      at TransformContext.error (file:///Users/tequ/project/dassie/node_modules/.pnpm/vite@3.2.2/node_modules/vite/dist/node/chunks/dep-c842e491.js:41164:19)
      at normalizeUrl (file:///Users/tequ/project/dassie/node_modules/.pnpm/vite@3.2.2/node_modules/vite/dist/node/chunks/dep-c842e491.js:38032:33)
      at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
      at async TransformContext.transform (file:///Users/tequ/project/dassie/node_modules/.pnpm/vite@3.2.2/node_modules/vite/dist/node/chunks/dep-c842e491.js:38165:47)
      at async Object.transform (file:///Users/tequ/project/dassie/node_modules/.pnpm/vite@3.2.2/node_modules/vite/dist/node/chunks/dep-c842e491.js:41421:30)
      at async loadAndTransform (file:///Users/tequ/project/dassie/node_modules/.pnpm/vite@3.2.2/node_modules/vite/dist/node/chunks/dep-c842e491.js:37808:29)
4:19:12 [vite] Internal server error: Failed to resolve import "@dassie/lib-reactive" from "packages/lib-reactive-react/src/index.ts". Does the file exist?
```