### PR TITLE
feat: require node >= 20 for crypto.subtle (< @noble/ed25519)

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ In order to develop a peer-to-peer application, it is very useful to quickly spi
 
 ### Prerequisites
 
-- Node.js 18
+- Node.js 20 (crypto.subtle)
 - [mkcert](https://github.com/FiloSottile/mkcert)
   1. Run `mkcert -install` to create the private CA and register it in your OS and browser.
   2. Add `export NODE_EXTRA_CA_CERTS="$(mkcert -CAROOT)/rootCA.pem"` to your `.bashrc`, `.zshrc`, or similar.

--- a/package.json
+++ b/package.json
@@ -59,6 +59,9 @@
     "eslint": "^8.41.0",
     "turbo": "^1.9.9"
   },
+  "engines": {
+    "node": ">=20.0.0"
+  },
   "pnpm": {
     "peerDependencyRules": {
       "ignoreMissing": [


### PR DESCRIPTION
edit: Actually, I must have gotten confused about what exactly was causing the problem, as node 18 /seems/ to expose crypto.subtle ?? There was definitely a complaint about crypto.subtle which seemed to disappear, after upgrading node from 18 to 20 though:

```
Error: crypto.subtle or etc.sha512Async must be defined
  at err (file:///Users/nicholasdudfield/projects/dassie/node_modules/.pnpm/@noble+ed25519@2.0.0/node_modules/@noble/ed25519/index.js:11:33)
  at Object.sha512Async (file:///Users/nicholasdudfield/projects/dassie/node_modules/.pnpm/@noble+ed25519@2.0.0/node_modules/@noble/ed25519/index.js:313:13)
  at sha512a (file:///Users/nicholasdudfield/projects/dassie/node_modules/.pnpm/@noble+ed25519@2.0.0/node_modules/@noble/ed25519/index.js:232:31)
  at getExtendedPublicKeyAsync (file:///Users/nicholasdudfield/projects/dassie/node_modules/.pnpm/@noble+ed25519@2.0.0/node_modules/@noble/ed25519/index.js:247:45)
  at Module.signAsync (file:///Users/nicholasdudfield/projects/dassie/node_modules/.pnpm/@noble+ed25519@2.0.0/node_modules/@noble/ed25519/index.js:269:21)
  at Object.signWithDassieKey (/Users/nicholasdudfield/projects/dassie/packages/app-node/src/backend/crypto/signer.ts:13:16)
  at Object.maintainOwnNodeTableEntry [as behavior] (/Users/nicholasdudfield/projects/dassie/packages/app-node/src/backend/peer-protocol/maintain-own-node-table-entry.ts:68:38)
  at loopActor (/Users/nicholasdudfield/projects/dassie/packages/lib-reactive/src/actor.ts:262:33)
  at Object.run (/Users/nicholasdudfield/projects/dassie/packages/lib-reactive/src/actor.ts:175:12)
  at ActorContext.run (/Users/nicholasdudfield/projects/dassie/packages/lib-reactive/src/context.ts:292:8)
```

I was trying Dassie on my new machine and was getting a bunch of errors (which I unfortunately didn't save) but it turns out one of the dependencies requires crypto.subtle to be available. 

This might actually work on node 19, but given node 20 is the current node release, and in October the new LTS, why not just specify v20 ? 

Related note:
Might be nice if it did an environment check on startup, to check for mkcert, openssl ed25519 support and that `NODE_EXTRA_CA_CERTS` is set. For the latter, maybe it just automatically runs the mkcert -CAROOT command ? 

Related question:
While trying to debug the "can't connect" issues, I added a bunch of aliases for n\d.localhost in /etc/hosts. Not sure if that's a step that needs to be done, or it magically works without them ?  (edit: it seems it's a required step) 